### PR TITLE
DE-804: modifications for multiple users, groups, etc

### DIFF
--- a/functions/notify_slack.py
+++ b/functions/notify_slack.py
@@ -4,6 +4,8 @@ import os, boto3, json, base64
 import urllib.request, urllib.parse
 import logging
 
+from slack_sdk.errors import SlackApiError
+from utils import get_slack
 
 # Decrypt encrypted URL with KMS
 def decrypt(encrypted_url):
@@ -66,59 +68,77 @@ def default_notification(subject, message):
 
 # Send a message to a slack channel
 def notify_slack(subject, message, region):
-  slack_url = os.environ['SLACK_WEBHOOK_URL']
-  if not slack_url.startswith("http"):
-    slack_url = decrypt(slack_url)
+  if not (slack_channels := os.environ.get('SLACK_CHANNELS')):
+    raise ValueError("Env var SLACK_CHANNELS is not set! Check the configuration")
 
-  slack_channel = os.environ['SLACK_CHANNEL']
-  slack_username = os.environ['SLACK_USERNAME']
-  slack_emoji = os.environ['SLACK_EMOJI']
+  slack_channels = slack_channels.split(',')
+  slack_users = os.environ.get('SLACK_USERS', '').split(',')
+  slack_groups = os.environ.get('SLACK_GROUPS', '').split(',')
+  slack_emoji = os.environ.get('SLACK_EMOJI', ':aws:')
 
   payload = {
-    "channel": slack_channel,
-    "username": slack_username,
+    "region": region,
+    "channels": slack_channels,
+    "users": slack_users,
+    "groups": slack_groups,
     "icon_emoji": slack_emoji,
-    "attachments": []
+    "attachments": [],
+    "msgs_sent": 0,
   }
 
-  if type(message) is str:
+  # Convert the message from a json string to a dict
+  if isinstance(message, str):
     try:
       message = json.loads(message)
     except json.JSONDecodeError as err:
-      logging.exception(f'JSON decode error: {err}')
+      logging.info(f'No JSON in SNS message, using the SNS message as the slack msg - err: {err}')
+      message = {'text': message}
 
-  if "AlarmName" in message:
+  text = ""
+  # Don't add extra lines unless there are values to iterate on
+  if len(slack_users) > 0 and slack_users[0] :
+    text += '\n' + ", ".join('<@' + whom + '>' for whom in slack_users if whom != '')
+  if len(slack_groups) > 0:
+    text += '\n' + ", ".join('<!subteam^' + group + '>' for group in slack_groups if group != '')
+  text += '\n'
+
+  # Based on the notification type, format text
+  if alarm_name := message.get("AlarmName") in message:
     notification = cloudwatch_notification(message, region)
-    payload['text'] = "AWS CloudWatch notification - " + message["AlarmName"]
-    payload['attachments'].append(notification)
-  elif "attachments" in message or "text" in message:
-    payload = {**payload, **message}
+    payload['text'] = text + "AWS CloudWatch notification - " + alarm_name
+  elif "text" in message:
+    payload['text'] = text + message['text']
   else:
-    payload['text'] = "AWS notification"
-    payload['attachments'].append(default_notification(subject, message))
+    payload['text'] = text + "AWS notification"
 
-  data = urllib.parse.urlencode({"payload": json.dumps(payload)}).encode("utf-8")
-  req = urllib.request.Request(slack_url)
+  slack = get_slack()
+  for channel in slack_channels:
+    response = slack.send_message(channel, subject, payload['text'])
+    payload['msgs_sent'] += 1
+    logging.debug(f"Sent slack message to {channel} - success={response.get('ok', False)}")
 
-  try:
-    result = urllib.request.urlopen(req, data)
-    return json.dumps({"code": result.getcode(), "info": result.info().as_string()})
-
-  except HTTPError as e:
-    logging.error("{}: result".format(e))
-    return json.dumps({"code": e.getcode(), "info": e.info().as_string()})
-
+  return payload
 
 def lambda_handler(event, context):
-  if 'LOG_EVENTS' in os.environ and os.environ['LOG_EVENTS'] == 'True':
+  if os.environ.get('LOG_EVENTS', 'False').title() == 'True':
     logging.warning('Event logging enabled: `{}`'.format(json.dumps(event)))
 
   subject = event['Records'][0]['Sns']['Subject']
   message = event['Records'][0]['Sns']['Message']
   region = event['Records'][0]['Sns']['TopicArn'].split(":")[3]
+
   response = notify_slack(subject, message, region)
+  return {
+      'statusCode': 200,
+      'headers': {
+        'Content-Type': 'application/json'
+      },
+      'body': json.dumps(response)
+  }
 
-  if json.loads(response)["code"] != 200:
-    logging.error("Error: received status `{}` using event `{}` and context `{}`".format(json.loads(response)["info"], event, context))
 
-  return response
+if __name__ == "__main__":
+  from notify_slack_test import events
+  logging.getLogger().setLevel(logging.DEBUG)
+  for event in events:
+    response = notify_slack('subject', event, 'eu-west-1')

--- a/functions/notify_slack_test.py
+++ b/functions/notify_slack_test.py
@@ -2,7 +2,7 @@
 
 import notify_slack
 import pytest
-from json import loads
+import json
 from os import environ
 
 events = (
@@ -164,7 +164,7 @@ events = (
 
 @pytest.fixture(scope='module', autouse=True)
 def check_environment_variables():
-    required_environment_variables = ("SLACK_CHANNEL", "SLACK_EMOJI", "SLACK_USERNAME", "SLACK_WEBHOOK_URL")
+    required_environment_variables = ("SLACK_CHANNELS", "SLACK_EMOJI", "SLACK_USERS")
     missing_environment_variables = []
     for k in required_environment_variables:
         if k not in environ:
@@ -178,9 +178,8 @@ def check_environment_variables():
 def test_lambda_handler(event):
     if 'Records' in event:
         response = notify_slack.lambda_handler(event, 'self-context')
-
+        msgs_sent = json.loads(response['body'])['msgs_sent']
     else:
         response = notify_slack.notify_slack('subject', event, 'eu-west-1')
-
-    response = loads(response)
-    assert response['code'] == 200
+        msgs_sent = response['msgs_sent']
+    assert msgs_sent > 0

--- a/functions/pytest.ini.sample
+++ b/functions/pytest.ini.sample
@@ -1,8 +1,8 @@
 [pytest]
 addopts = --disable-pytest-warnings
 env =
-  SLACK_CHANNEL=slack_testing_sandbox
+  ENV=local
+  SLACK_CHANNELS=slack_testing_sandbox
   SLACK_EMOJI=:aws:
-  SLACK_USERNAME=notify_slack_test
-  SLACK_WEBHOOK_URL=https://hooks.slack.com/services/YOUR/WEBOOK/URL
-
+  SLACK_USERS=notify_slack_test
+  LOG_EVENTS=True

--- a/functions/requirements.txt
+++ b/functions/requirements.txt
@@ -1,4 +1,5 @@
 boto3
+slack_sdk
 
 pytest
 pytest-env

--- a/functions/utils.py
+++ b/functions/utils.py
@@ -1,0 +1,78 @@
+import json
+import os
+import logging
+from functools import lru_cache
+
+import boto3
+from botocore.exceptions import ClientError
+
+from slack_sdk import WebClient
+from slack_sdk.errors import SlackApiError
+
+
+LOG = logging.getLogger(__name__)
+
+
+class LocalSlack:
+  @staticmethod
+  def send_message(channel, subject, message):
+    if slack_api_token := os.environ.get('SLACK_API_TOKEN'):
+      LOG.info(f"Found SLACK_API_TOKEN, posting slack message: {message}")
+      slack_api_token = os.environ.get('SLACK_API_TOKEN') or get_secrets()
+      client = Slack(slack_api_token, os.environ['ENV'])
+      return client.send_message(channel, subject, message)
+    else:
+      LOG.info("SLACK_API_TOKEN is not set - logging message")
+      LOG.info(f"{channel}: {message}")
+      return {"ok": True} 
+
+class Slack:
+  def __init__(self, slack_api_token, env):
+    self.client = WebClient(token=slack_api_token)
+    self.env = env
+
+  def send_message(self, channel, subject, message):
+    return self.client.chat_postMessage(
+      channel=channel,
+      blocks=[
+          {
+            "type": "header",
+            "text": {
+              "type": "plain_text",
+              "text": subject,
+              "emoji": True
+            }
+          },
+          {
+              "type": "section",
+              "text": {
+                  "type": "mrkdwn",
+                  "text": message
+              }
+          },
+          {
+              "type": "context",
+              "elements": [
+                  {
+                      "type": "plain_text",
+                      "text": f"ENV: {self.env}"
+                  }
+              ]
+          }
+      ])
+
+
+@lru_cache(maxsize=1)
+def get_slack():
+  """
+  :return: SlackObject
+  """
+  env = os.getenv('ENV', 'local')
+  if env not in ['testing', 'local']:
+    slack_api_token = os.environ.get('SLACK_API_TOKEN') or get_secrets()
+    slack = Slack(slack_api_token, env)
+    if not slack.auth_test().get('ok', False):
+      raise SlackApiError("Could not authenticate Slack WebClient using env api_token")
+  else:
+    return LocalSlack()
+

--- a/main.tf
+++ b/main.tf
@@ -90,9 +90,10 @@ module "lambda" {
   publish = true
 
   environment_variables = {
-    SLACK_WEBHOOK_URL = var.slack_webhook_url
-    SLACK_CHANNEL     = var.slack_channel
-    SLACK_USERNAME    = var.slack_username
+    SLACK_API_TOKEN   = var.slack_api_token
+    SLACK_CHANNELS    = var.slack_channels
+    SLACK_USERS       = var.slack_users
+    SLACK_GROUPS      = var.slack_groups
     SLACK_EMOJI       = var.slack_emoji
     LOG_EVENTS        = var.log_events ? "True" : "False"
   }


### PR DESCRIPTION
- Added multiple slack_users/channels/groups 
- Edited terraform for new env vars
- Uses SLACK_API_TOKEN instead of webhook
- Added slack_sdk library
- Adjusted tests for new code

Suggestions welcome! Looking for thoughts on:
- How to store the SLACK_API_TOKEN? Should it be done through SecretsManager and inserted into terraform? 
- Formatting for Slack message could be improved, especially for future use cases - should we ingest JSONs in a particular format for customization of messaging? 
- I tried to minimize code impact to keep upstream as similar as possible for original repo merges


